### PR TITLE
Make the library compatible with Instant Apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ captures/
 *.iml
 .idea/*
 
+# macOS
+.DS_Store
+
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
 #*.jks

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
@@ -11,7 +11,6 @@ import android.hardware.SensorManager
 import android.hardware.input.InputManager
 import android.media.MediaCodecList
 import android.media.RingtoneManager
-import android.os.Build
 import android.os.Environment
 import android.os.StatFs
 import androidx.core.hardware.fingerprint.FingerprintManagerCompat
@@ -197,14 +196,9 @@ object FingerprinterFactory {
         context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
     )
 
-    private fun createCodecInfoProvider() =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            CodecInfoProviderImpl(
-                MediaCodecList(MediaCodecList.ALL_CODECS)
-            )
-        } else {
-            null
-        }
+    private fun createCodecInfoProvider() = CodecInfoProviderImpl(
+        MediaCodecList(MediaCodecList.ALL_CODECS)
+    )
 
     private fun createBatteryInfoDataSource(context: Context) = BatteryInfoProviderImpl(
         context

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
@@ -142,9 +142,14 @@ object FingerprinterFactory {
         val internalStorageDir = Environment.getRootDirectory().absolutePath
         val internalStorageStatFs = StatFs(internalStorageDir)
 
-        val externalStorageDir = context.getExternalFilesDir(null)?.absolutePath
+        val externalStorageDir = context.getExternalFilesDir(null)
+        val externalStorageDirPath = externalStorageDir?.absolutePath
         val externalStorageStatFs =
-            if (externalStorageDir != null) StatFs(externalStorageDir) else null
+            if (externalStorageDirPath != null && externalStorageDir.canRead()) {
+                StatFs(externalStorageDirPath)
+            } else {
+                null
+            }
 
         return MemInfoProviderImpl(
             activityManager,

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
@@ -192,8 +192,8 @@ object FingerprinterFactory {
         )
 
     private fun createDeviceSecurityProvider(context: Context) = DeviceSecurityInfoProviderImpl(
-        context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager,
-        context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        context.getSystemService(Context.DEVICE_POLICY_SERVICE) as? DevicePolicyManager,
+        context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
     )
 
     private fun createCodecInfoProvider() = CodecInfoProviderImpl(

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DeviceSecurityInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DeviceSecurityInfoProvider.kt
@@ -14,12 +14,12 @@ interface DeviceSecurityInfoProvider {
 }
 
 internal class DeviceSecurityInfoProviderImpl(
-    private val devicePolicyManager: DevicePolicyManager,
-    private val keyguardManager: KeyguardManager
+    private val devicePolicyManager: DevicePolicyManager?,
+    private val keyguardManager: KeyguardManager?
 ) : DeviceSecurityInfoProvider {
     override fun encryptionStatus(): String {
         return executeSafe({
-            stringDescriptionForEncryptionStatus(devicePolicyManager.storageEncryptionStatus)
+            stringDescriptionForEncryptionStatus(devicePolicyManager?.storageEncryptionStatus)
         }, "")
     }
 
@@ -32,11 +32,11 @@ internal class DeviceSecurityInfoProviderImpl(
     }
 
     override fun isPinSecurityEnabled() = executeSafe(
-        { keyguardManager.isKeyguardSecure }, false
+        { keyguardManager?.isKeyguardSecure ?: false }, false
     )
 }
 
-private fun stringDescriptionForEncryptionStatus(status: Int): String {
+private fun stringDescriptionForEncryptionStatus(status: Int?): String {
     return when (status) {
         DevicePolicyManager.ENCRYPTION_STATUS_UNSUPPORTED -> UNSUPPORTED
         DevicePolicyManager.ENCRYPTION_STATUS_INACTIVE -> INACTIVE


### PR DESCRIPTION
Due to some restrictions applied to Instant Apps the fingerprint library crashes when the instance is created.

Adjustments:
- check if externalStorageDir is readable before trying to access it, would crash otherwise
- made DevicePolicyManager and KeyguardManager optional, would crash otherwise
- remove unnecessary build version code check