### PR TITLE
Add multi-user and 'Instant App' use-case to the stability table

### DIFF
--- a/docs/stability.md
+++ b/docs/stability.md
@@ -12,3 +12,4 @@
 | Repackaging the application | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | System update | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Different 'User' on the same device  | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| Instant App compared to a regular app  | ❌ | ❌ | ❌ (not available) | ❌ | ❌ | ❌ (not available) | ❌ |

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -11,3 +11,4 @@
 | Factory reset | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Repackaging the application | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | System update | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Different 'User' on the same device  | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |


### PR DESCRIPTION
I tried the Playground app with different 'Users' on my device (https://source.android.com/devices/tech/admin/multi-user) and discovered that the GSF ID is not stable.
~The ID that stayed the same is the Media DRM ID, thats why i introduced `stabilityVersion 4` that uses the DRM ID as the default id, if available.~

When fingerprintjs is run within an Instant App the GSF ID and Installed Apps fingerprint is not available at all. All other IDs and fingerprints are different from a regular app.

I ~also~ add this information to the stability documentation ~and updated the README.~