### PR TITLE
Fix getSignalsMatching when passed V1 as version + minor refactor

### DIFF
--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignal.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignal.kt
@@ -8,8 +8,8 @@ import com.fingerprintjs.android.fingerprint.signal_providers.StabilityLevel
  */
 public sealed class FingerprintingSignal<out T> {
     /**
-     * "Meta" information about the signal. Each signal must
-     * also contain a static version of this property.
+     * "Meta" information about the signal. Must reference
+     * a static version of this property which must also be exposed.
      */
     public abstract val info: Info
     /**

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignalsProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignalsProvider.kt
@@ -2,9 +2,26 @@ package com.fingerprintjs.android.fingerprint.fingerprinting_signals
 
 import androidx.annotation.WorkerThread
 import com.fingerprintjs.android.fingerprint.Fingerprinter
-import com.fingerprintjs.android.fingerprint.info_providers.*
+import com.fingerprintjs.android.fingerprint.info_providers.BatteryInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.CameraInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.CodecInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.CpuInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.DevicePersonalizationInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.DeviceSecurityInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.FingerprintSensorInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.GpuInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.InputDeviceDataSource
+import com.fingerprintjs.android.fingerprint.info_providers.MemInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.OsBuildInfoProvider
+import com.fingerprintjs.android.fingerprint.info_providers.PackageManagerDataSource
+import com.fingerprintjs.android.fingerprint.info_providers.SensorDataSource
+import com.fingerprintjs.android.fingerprint.info_providers.SettingsDataSource
 import com.fingerprintjs.android.fingerprint.signal_providers.StabilityLevel
-import com.fingerprintjs.android.fingerprint.tools.inRange
+import com.fingerprintjs.android.fingerprint.tools.FingerprintingLegacySchemeSupportExtensions.getDeviceStateSignals
+import com.fingerprintjs.android.fingerprint.tools.FingerprintingLegacySchemeSupportExtensions.getHardwareSignals
+import com.fingerprintjs.android.fingerprint.tools.FingerprintingLegacySchemeSupportExtensions.getInstalledAppsSignals
+import com.fingerprintjs.android.fingerprint.tools.FingerprintingLegacySchemeSupportExtensions.getOsBuildSignals
+import com.fingerprintjs.android.fingerprint.tools.SignalsUtils
 
 /**
  * A class that provides signals used in the [Fingerprinter's][com.fingerprintjs.android.fingerprint.Fingerprinter]
@@ -31,22 +48,6 @@ public class FingerprintingSignalsProvider internal constructor(
     private val devicePersonalizationInfoProvider: DevicePersonalizationInfoProvider,
     private val fingerprintSensorInfoProvider: FingerprintSensorInfoProvider,
 ) {
-
-    private fun <T : FingerprintingSignal<*>> createSignalIfNeeded(
-        requiredVersion: Fingerprinter.Version,
-        requiredStabilityLevel: StabilityLevel,
-        signalFingerprintingInfo: FingerprintingSignal.Info,
-        signalFactory: () -> T,
-    ): T? {
-        return if (
-            signalFingerprintingInfo.stabilityLevel.atLeastAsStableAs(requiredStabilityLevel)
-            && requiredVersion.inRange(signalFingerprintingInfo.addedInVersion, signalFingerprintingInfo.removedInVersion)
-        )
-            signalFactory.invoke()
-        else
-            null
-    }
-
     /**
      * A shorthand method returning the subset of signals listed below in the class
      * with respect to provided parameters.
@@ -65,7 +66,7 @@ public class FingerprintingSignalsProvider internal constructor(
         version: Fingerprinter.Version,
         stabilityLevel: StabilityLevel
     ): List<FingerprintingSignal<*>> {
-        return listOf(
+        val allSignalsInfoToFactory = listOf(
             ManufacturerNameSignal.info to { manufacturerNameSignal },
             ModelNameSignal.info to { modelNameSignal },
             TotalRamSignal.info to { totalRamSignal },
@@ -115,13 +116,36 @@ public class FingerprintingSignalsProvider internal constructor(
             RegionCountrySignal.info to { regionCountrySignal },
             DefaultLanguageSignal.info to { defaultLanguageSignal },
             TimezoneSignal.info to { timezoneSignal },
-        ).mapNotNull {
-            createSignalIfNeeded(
-                requiredVersion = version,
-                requiredStabilityLevel = stabilityLevel,
-                signalFingerprintingInfo = it.first,
-                signalFactory = it.second
-            )
+        )
+
+        return when (version) {
+            // for legacy versions, the info object does not tell us entirely whether the signal should be retrieved,
+            // hence a custom logic here
+            in Fingerprinter.Version.V_1..Fingerprinter.Version.fingerprintingGroupedSignalsLastVersion -> {
+                listOf(
+                    this.getHardwareSignals(version, stabilityLevel),
+                    this.getOsBuildSignals(version, stabilityLevel),
+                    this.getDeviceStateSignals(version, stabilityLevel),
+                    this.getInstalledAppsSignals(version, stabilityLevel),
+                )
+                    .flatten()
+                    .sortedBy { signal ->
+                        // we can compare by reference because an info is always static by design
+                        allSignalsInfoToFactory.indexOfFirst { it.first === signal.info }
+                    }
+            }
+
+            else -> {
+                allSignalsInfoToFactory.mapNotNull {
+                    SignalsUtils.createSignalIfNeeded(
+                        requiredVersion = version,
+                        requiredStabilityLevel = stabilityLevel,
+                        signalFingerprintingInfo = it.first,
+                        signalFactory = it.second
+                    )
+                }
+
+            }
         }
     }
 
@@ -129,194 +153,242 @@ public class FingerprintingSignalsProvider internal constructor(
     public val manufacturerNameSignal: ManufacturerNameSignal by lazy {
         ManufacturerNameSignal(osBuildInfoProvider.manufacturerName())
     }
+
     @get:WorkerThread
     public val modelNameSignal: ModelNameSignal by lazy {
         ModelNameSignal(osBuildInfoProvider.modelName())
     }
+
     @get:WorkerThread
     public val totalRamSignal: TotalRamSignal by lazy {
         TotalRamSignal(memInfoProvider.totalRAM())
     }
+
     @get:WorkerThread
     public val totalInternalStorageSpaceSignal: TotalInternalStorageSpaceSignal by lazy {
         TotalInternalStorageSpaceSignal(memInfoProvider.totalInternalStorageSpace())
     }
+
     @get:WorkerThread
     public val procCpuInfoSignal: ProcCpuInfoSignal by lazy {
         ProcCpuInfoSignal(cpuInfoProvider.cpuInfo())
     }
+
     @get:WorkerThread
     public val procCpuInfoV2Signal: ProcCpuInfoV2Signal by lazy {
         ProcCpuInfoV2Signal(cpuInfoProvider.cpuInfoV2())
     }
+
     @get:WorkerThread
     public val sensorsSignal: SensorsSignal by lazy {
         SensorsSignal(sensorsDataSource.sensors())
     }
+
     @get:WorkerThread
     public val inputDevicesSignal: InputDevicesSignal by lazy {
         InputDevicesSignal(inputDeviceDataSource.getInputDeviceData())
     }
+
     @get:WorkerThread
     public val inputDevicesV2Signal: InputDevicesV2Signal by lazy {
         InputDevicesV2Signal(inputDeviceDataSource.getInputDeviceData())
     }
+
     @get:WorkerThread
     public val batteryHealthSignal: BatteryHealthSignal by lazy {
         BatteryHealthSignal(batteryInfoProvider.batteryHealth())
     }
+
     @get:WorkerThread
     public val batteryFullCapacitySignal: BatteryFullCapacitySignal by lazy {
         BatteryFullCapacitySignal(batteryInfoProvider.batteryTotalCapacity())
     }
+
     @get:WorkerThread
     public val cameraListSignal: CameraListSignal by lazy {
         CameraListSignal(cameraInfoProvider.getCameraInfo())
     }
+
     @get:WorkerThread
     public val glesVersionSignal: GlesVersionSignal by lazy {
         GlesVersionSignal(gpuInfoProvider.glesVersion())
     }
+
     @get:WorkerThread
     public val abiTypeSignal: AbiTypeSignal by lazy {
         AbiTypeSignal(cpuInfoProvider.abiType())
     }
+
     @get:WorkerThread
     public val coresCountSignal: CoresCountSignal by lazy {
         CoresCountSignal(cpuInfoProvider.coresCount())
     }
+
     @get:WorkerThread
     public val fingerprintSignal: FingerprintSignal by lazy {
         FingerprintSignal(osBuildInfoProvider.fingerprint())
     }
+
     @get:WorkerThread
     public val androidVersionSignal: AndroidVersionSignal by lazy {
         AndroidVersionSignal(osBuildInfoProvider.androidVersion())
     }
+
     @get:WorkerThread
     public val sdkVersionSignal: SdkVersionSignal by lazy {
         SdkVersionSignal(osBuildInfoProvider.sdkVersion())
     }
+
     @get:WorkerThread
     public val kernelVersionSignal: KernelVersionSignal by lazy {
         KernelVersionSignal(osBuildInfoProvider.kernelVersion())
     }
+
     @get:WorkerThread
     public val encryptionStatusSignal: EncryptionStatusSignal by lazy {
         EncryptionStatusSignal(deviceSecurityInfoProvider.encryptionStatus())
     }
+
     @get:WorkerThread
     public val codecListSignal: CodecListSignal by lazy {
         CodecListSignal(codecInfoProvider?.codecsList() ?: emptyList())
     }
+
     @get:WorkerThread
     public val securityProvidersSignal: SecurityProvidersSignal by lazy {
         SecurityProvidersSignal(deviceSecurityInfoProvider.securityProvidersData())
     }
+
     @get:WorkerThread
     public val applicationsListSignal: ApplicationsListSignal by lazy {
         ApplicationsListSignal(packageManagerDataSource.getApplicationsList())
     }
+
     @get:WorkerThread
     public val systemApplicationsListSignal: SystemApplicationsListSignal by lazy {
         SystemApplicationsListSignal(packageManagerDataSource.getSystemApplicationsList())
     }
+
     @get:WorkerThread
     public val adbEnabledSignal: AdbEnabledSignal by lazy {
         AdbEnabledSignal(settingsDataSource.adbEnabled())
     }
+
     @get:WorkerThread
     public val developmentSettingsEnabledSignal: DevelopmentSettingsEnabledSignal by lazy {
         DevelopmentSettingsEnabledSignal(settingsDataSource.developmentSettingsEnabled())
     }
+
     @get:WorkerThread
     public val httpProxySignal: HttpProxySignal by lazy {
         HttpProxySignal(settingsDataSource.httpProxy())
     }
+
     @get:WorkerThread
     public val transitionAnimationScaleSignal: TransitionAnimationScaleSignal by lazy {
         TransitionAnimationScaleSignal(settingsDataSource.transitionAnimationScale())
     }
+
     @get:WorkerThread
     public val windowAnimationScaleSignal: WindowAnimationScaleSignal by lazy {
         WindowAnimationScaleSignal(settingsDataSource.windowAnimationScale())
     }
+
     @get:WorkerThread
     public val dataRoamingEnabledSignal: DataRoamingEnabledSignal by lazy {
         DataRoamingEnabledSignal(settingsDataSource.dataRoamingEnabled())
     }
+
     @get:WorkerThread
     public val accessibilityEnabledSignal: AccessibilityEnabledSignal by lazy {
         AccessibilityEnabledSignal(settingsDataSource.accessibilityEnabled())
     }
+
     @get:WorkerThread
     public val defaultInputMethodSignal: DefaultInputMethodSignal by lazy {
         DefaultInputMethodSignal(settingsDataSource.defaultInputMethod())
     }
+
     @get:WorkerThread
     public val rttCallingModeSignal: RttCallingModeSignal by lazy {
         RttCallingModeSignal(settingsDataSource.rttCallingMode())
     }
+
     @get:WorkerThread
     public val touchExplorationEnabledSignal: TouchExplorationEnabledSignal by lazy {
         TouchExplorationEnabledSignal(settingsDataSource.touchExplorationEnabled())
     }
+
     @get:WorkerThread
     public val alarmAlertPathSignal: AlarmAlertPathSignal by lazy {
         AlarmAlertPathSignal(settingsDataSource.alarmAlertPath())
     }
+
     @get:WorkerThread
     public val dateFormatSignal: DateFormatSignal by lazy {
         DateFormatSignal(settingsDataSource.dateFormat())
     }
+
     @get:WorkerThread
     public val endButtonBehaviourSignal: EndButtonBehaviourSignal by lazy {
         EndButtonBehaviourSignal(settingsDataSource.endButtonBehaviour())
     }
+
     @get:WorkerThread
     public val fontScaleSignal: FontScaleSignal by lazy {
         FontScaleSignal(settingsDataSource.fontScale())
     }
+
     @get:WorkerThread
     public val screenOffTimeoutSignal: ScreenOffTimeoutSignal by lazy {
         ScreenOffTimeoutSignal(settingsDataSource.screenOffTimeout())
     }
+
     @get:WorkerThread
     public val textAutoReplaceEnabledSignal: TextAutoReplaceEnabledSignal by lazy {
         TextAutoReplaceEnabledSignal(settingsDataSource.textAutoReplaceEnable())
     }
+
     @get:WorkerThread
     public val textAutoPunctuateSignal: TextAutoPunctuateSignal by lazy {
         TextAutoPunctuateSignal(settingsDataSource.textAutoPunctuate())
     }
+
     @get:WorkerThread
     public val time12Or24Signal: Time12Or24Signal by lazy {
         Time12Or24Signal(settingsDataSource.time12Or24())
     }
+
     @get:WorkerThread
     public val isPinSecurityEnabledSignal: IsPinSecurityEnabledSignal by lazy {
         IsPinSecurityEnabledSignal(deviceSecurityInfoProvider.isPinSecurityEnabled())
     }
+
     @get:WorkerThread
     public val fingerprintSensorStatusSignal: FingerprintSensorStatusSignal by lazy {
         FingerprintSensorStatusSignal(fingerprintSensorInfoProvider.getStatus().stringDescription)
     }
+
     @get:WorkerThread
     public val ringtoneSourceSignal: RingtoneSourceSignal by lazy {
         RingtoneSourceSignal(devicePersonalizationInfoProvider.ringtoneSource())
     }
+
     @get:WorkerThread
     public val availableLocalesSignal: AvailableLocalesSignal by lazy {
         AvailableLocalesSignal(devicePersonalizationInfoProvider.availableLocales().toList())
     }
+
     @get:WorkerThread
     public val regionCountrySignal: RegionCountrySignal by lazy {
         RegionCountrySignal(devicePersonalizationInfoProvider.regionCountry())
     }
+
     @get:WorkerThread
     public val defaultLanguageSignal: DefaultLanguageSignal by lazy {
         DefaultLanguageSignal(devicePersonalizationInfoProvider.defaultLanguage())
     }
+
     @get:WorkerThread
     public val timezoneSignal: TimezoneSignal by lazy {
         TimezoneSignal(devicePersonalizationInfoProvider.timezone())

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/FingerprintingLegacySchemeSupportExtensions.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/FingerprintingLegacySchemeSupportExtensions.kt
@@ -5,23 +5,6 @@ import com.fingerprintjs.android.fingerprint.fingerprinting_signals.*
 import com.fingerprintjs.android.fingerprint.signal_providers.StabilityLevel
 
 internal object FingerprintingLegacySchemeSupportExtensions {
-
-    private fun <T: FingerprintingSignal<*>>createSignalIfNeeded(
-        requiredVersion: Fingerprinter.Version,
-        requiredStabilityLevel: StabilityLevel,
-        signalFingerprintingInfo: FingerprintingSignal.Info,
-        signalFactory: () -> T,
-    ): T? {
-
-        return if (
-            signalFingerprintingInfo.stabilityLevel.atLeastAsStableAs(requiredStabilityLevel)
-            && requiredVersion.inRange(signalFingerprintingInfo.addedInVersion, signalFingerprintingInfo.removedInVersion)
-        )
-            signalFactory.invoke()
-        else
-            null
-    }
-
     fun FingerprintingSignalsProvider.getHardwareSignals(
         version: Fingerprinter.Version,
         stabilityLevel: StabilityLevel,
@@ -76,7 +59,7 @@ internal object FingerprintingLegacySchemeSupportExtensions {
                 )
             }
         }.mapNotNull {
-            createSignalIfNeeded(
+            SignalsUtils.createSignalIfNeeded(
                 requiredVersion = version,
                 requiredStabilityLevel = stabilityLevel,
                 signalFingerprintingInfo = it.first,
@@ -107,7 +90,7 @@ internal object FingerprintingLegacySchemeSupportExtensions {
                 )
             }
         }.mapNotNull {
-            createSignalIfNeeded(
+            SignalsUtils.createSignalIfNeeded(
                 requiredVersion = version,
                 requiredStabilityLevel = stabilityLevel,
                 signalFingerprintingInfo = it.first,
@@ -179,7 +162,7 @@ internal object FingerprintingLegacySchemeSupportExtensions {
                 )
             }
         }.mapNotNull {
-            createSignalIfNeeded(
+            SignalsUtils.createSignalIfNeeded(
                 requiredVersion = version,
                 requiredStabilityLevel = overriddenStabilityLevel,
                 signalFingerprintingInfo = it.first,
@@ -210,7 +193,7 @@ internal object FingerprintingLegacySchemeSupportExtensions {
                 )
             }
         }.mapNotNull {
-            createSignalIfNeeded(
+            SignalsUtils.createSignalIfNeeded(
                 requiredVersion = version,
                 requiredStabilityLevel = overriddenStabilityLevel,
                 signalFingerprintingInfo = it.first,

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/SignalsUtils.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/SignalsUtils.kt
@@ -1,0 +1,23 @@
+package com.fingerprintjs.android.fingerprint.tools
+
+import com.fingerprintjs.android.fingerprint.Fingerprinter
+import com.fingerprintjs.android.fingerprint.fingerprinting_signals.FingerprintingSignal
+import com.fingerprintjs.android.fingerprint.signal_providers.StabilityLevel
+
+internal object SignalsUtils {
+
+    fun <T : FingerprintingSignal<*>> createSignalIfNeeded(
+        requiredVersion: Fingerprinter.Version,
+        requiredStabilityLevel: StabilityLevel,
+        signalFingerprintingInfo: FingerprintingSignal.Info,
+        signalFactory: () -> T,
+    ): T? {
+        return if (
+            signalFingerprintingInfo.stabilityLevel.atLeastAsStableAs(requiredStabilityLevel)
+            && requiredVersion.inRange(signalFingerprintingInfo.addedInVersion, signalFingerprintingInfo.removedInVersion)
+        )
+            signalFactory.invoke()
+        else
+            null
+    }
+}


### PR DESCRIPTION
**Problem**:
`getSignalsMatching(V1, Stable/Optimal)` returned a wrong list of signals, because this method did not take into account that when using `V1` version, some signals should be treated as `Stable` even if their stability level is `Optimal/Unique`.

**What is affected**
The problem did not affect our backward compatibility with older fingerprints, because the method `Fingerprinter.getFingerprint(..)` internally did not use `getSignalsMatching` for versions representing legacy fingerprint scheme (v1..v4) and already respected the rule described above.

Therefore, the only way to experience the problem was to use `getSignalsMatching(V1, Stable/Optimal)` directly, and I
highly doubt that someone uses `V1` for this purpose nowadays :) However, one could observe this bug when trying our demo app if the following steps were made:
1.  Change fingerprint version to V1
2.  Switch between optimal and unique stability levels

One could see that the fingerprint remains the same, even though the list of signals actually does change. After the fix, during the same steps the list of signals will remain the same as it should.
