### PR TITLE
Disable proguard for the library module. 

### DIFF
--- a/fingerprint/build.gradle.kts
+++ b/fingerprint/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
Was enabled by accident when moving to Kotlin DSL