### PR TITLE
Remove nested safe calls with timeouts, since it makes the code less …

### DIFF
--- a/fingerprint/build.gradle.kts
+++ b/fingerprint/build.gradle.kts
@@ -84,6 +84,12 @@ android {
     }
 }
 
+androidComponents {
+    onVariants {
+        it.androidTest?.packaging?.resources?.excludes?.add("META-INF/*")
+    }
+}
+
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
     if (!this.name.contains("Test")) {
         kotlinOptions.freeCompilerArgs += "-Xexplicit-api=warning"
@@ -94,7 +100,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Constants.kotlinVersion}")
     implementation("androidx.appcompat:appcompat:1.6.1")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.12.7")
+    testImplementation("io.mockk:mockk:1.12.8")
+    androidTestImplementation("io.mockk:mockk:1.12.8")
+    androidTestImplementation ("io.mockk:mockk-android:1.12.8")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.1.5")
     androidTestImplementation("androidx.test:runner:1.5.2")
 }

--- a/fingerprint/src/androidTest/AndroidManifest.xml
+++ b/fingerprint/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk tools:overrideLibrary="io.mockk, io.mockk.proxy.android"/>
+</manifest>

--- a/fingerprint/src/androidTest/java/com/fingerprintjs/android/fingerprint/utils/CallbackUtils.kt
+++ b/fingerprint/src/androidTest/java/com/fingerprintjs/android/fingerprint/utils/CallbackUtils.kt
@@ -1,4 +1,4 @@
-package com.fingerprintjs.android.playground.utils
+package com.fingerprintjs.android.fingerprint.utils
 
 import java.util.concurrent.CountDownLatch
 

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/Fingerprinter.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/Fingerprinter.kt
@@ -19,7 +19,6 @@ import com.fingerprintjs.android.fingerprint.tools.hashers.MurMur3x64x128Hasher
 import com.fingerprintjs.android.fingerprint.tools.logs.Logger
 import com.fingerprintjs.android.fingerprint.tools.logs.ePleaseReport
 import com.fingerprintjs.android.fingerprint.tools.threading.runOnAnotherThread
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.Safe
 import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
 
 
@@ -32,7 +31,7 @@ public class Fingerprinter internal constructor(
         // does not ruin an entire operation.
         // another option could be to not use timeout at all, since we have a lot of timeouts
         // deep inside.
-        safe(timeoutMs = Safe.timeoutLong) { implFactory() }
+        safe { implFactory() }
     }
 
     /**

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterFactory.kt
@@ -27,7 +27,7 @@ import com.fingerprintjs.android.fingerprint.signal_providers.installed_apps.Ins
 import com.fingerprintjs.android.fingerprint.signal_providers.os_build.OsBuildSignalGroupProvider
 import com.fingerprintjs.android.fingerprint.tools.hashers.Hasher
 import com.fingerprintjs.android.fingerprint.tools.hashers.MurMur3x64x128Hasher
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 /**
@@ -191,9 +191,9 @@ public object FingerprinterFactory {
 
     private fun createMemoryInfoProvider(context: Context): MemInfoProvider {
         return MemInfoProviderImpl(
-            activityManager = safe { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager }.getOrNull(),
-            internalStorageStats = safe { StatFs(Environment.getRootDirectory()!!.absolutePath!!) }.getOrNull(),
-            externalStorageStats = safe {
+            activityManager = safeWithTimeout { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager }.getOrNull(),
+            internalStorageStats = safeWithTimeout { StatFs(Environment.getRootDirectory()!!.absolutePath!!) }.getOrNull(),
+            externalStorageStats = safeWithTimeout {
                 context.getExternalFilesDir(null)
                     ?.takeIf { it.canRead() }
                     ?.let { StatFs(it.absolutePath!!) }!!
@@ -204,51 +204,51 @@ public object FingerprinterFactory {
     private fun createOsBuildInfoProvider() = OsBuildInfoProviderImpl()
 
     private fun createGsfIdProvider(context: Context) = GsfIdProvider(
-        safe { context.contentResolver!! }.getOrDefault(null)
+        safeWithTimeout { context.contentResolver!! }.getOrDefault(null)
     )
 
     private fun createMediaDrmProvider() = MediaDrmIdProvider()
 
     private fun createAndroidIdProvider(context: Context) = AndroidIdProvider(
-        safe { context.contentResolver!! }.getOrDefault(null)
+        safeWithTimeout { context.contentResolver!! }.getOrDefault(null)
     )
 
     private fun createSensorDataSource(context: Context) = SensorDataSourceImpl(
-        safe { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager }.getOrNull()
+        safeWithTimeout { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager }.getOrNull()
     )
 
     private fun createInputDevicesDataSource(context: Context) = InputDevicesDataSourceImpl(
-        safe { context.getSystemService(Context.INPUT_SERVICE) as InputManager }.getOrNull()
+        safeWithTimeout { context.getSystemService(Context.INPUT_SERVICE) as InputManager }.getOrNull()
     )
 
     private fun createPackageManagerDataSource(context: Context) = PackageManagerDataSourceImpl(
-        safe { context.packageManager!! }.getOrNull()
+        safeWithTimeout { context.packageManager!! }.getOrNull()
     )
 
     private fun createSettingsDataSource(context: Context) = SettingsDataSourceImpl(
-        safe { context.contentResolver!! }.getOrNull()
+        safeWithTimeout { context.contentResolver!! }.getOrNull()
     )
 
 
     private fun createDevicePersonalizationDataSource(context: Context) =
         DevicePersonalizationInfoProviderImpl(
-            ringtoneManager = safe { RingtoneManager(context) }.getOrNull(),
-            assetManager = safe { context.assets!! }.getOrNull(),
-            configuration = safe { context.resources!!.configuration!! }.getOrNull(),
+            ringtoneManager = safeWithTimeout { RingtoneManager(context) }.getOrNull(),
+            assetManager = safeWithTimeout { context.assets!! }.getOrNull(),
+            configuration = safeWithTimeout { context.resources!!.configuration!! }.getOrNull(),
         )
 
     private fun createFingerprintSensorStatusProvider(context: Context) =
         FingerprintSensorInfoProviderImpl(
-            safe { FingerprintManagerCompat.from(context)!! }.getOrNull()
+            safeWithTimeout { FingerprintManagerCompat.from(context)!! }.getOrNull()
         )
 
     private fun createDeviceSecurityProvider(context: Context) = DeviceSecurityInfoProviderImpl(
-        safe { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager }.getOrNull(),
-        safe { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager }.getOrNull(),
+        safeWithTimeout { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager }.getOrNull(),
+        safeWithTimeout { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager }.getOrNull(),
     )
 
     private fun createCodecInfoProvider() = CodecInfoProviderImpl(
-        safe { MediaCodecList(MediaCodecList.ALL_CODECS) }.getOrNull()
+        safeWithTimeout { MediaCodecList(MediaCodecList.ALL_CODECS) }.getOrNull()
     )
 
     private fun createBatteryInfoDataSource(context: Context) = BatteryInfoProviderImpl(context)
@@ -256,7 +256,7 @@ public object FingerprinterFactory {
     private fun createCameraInfoProvider(): CameraInfoProvider = CameraInfoProviderImpl()
 
     private fun createGpuInfoProvider(context: Context) =
-        GpuInfoProviderImpl(safe { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager }.getOrNull())
+        GpuInfoProviderImpl(safeWithTimeout { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager }.getOrNull())
 
     //endregion
 

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterImpl.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/FingerprinterImpl.kt
@@ -14,7 +14,6 @@ import com.fingerprintjs.android.fingerprint.signal_providers.os_build.OsBuildSi
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
 import com.fingerprintjs.android.fingerprint.tools.FingerprintingLegacySchemeSupportExtensions
 import com.fingerprintjs.android.fingerprint.tools.hashers.Hasher
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.Safe
 import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
 
 
@@ -25,6 +24,7 @@ internal class FingerprinterImpl internal constructor(
 ) {
     @Volatile
     private var deviceIdResult: DeviceIdResult? = null
+
     @Volatile
     private var fingerprintResult: FingerprintResult? = null
 
@@ -33,7 +33,7 @@ internal class FingerprinterImpl internal constructor(
     fun getDeviceId(): Result<DeviceIdResult> {
         require(legacyArgs != null)
 
-        return safe(timeoutMs = Safe.timeoutLong) {
+        return safe {
             deviceIdResult?.let { return@safe it }
             val deviceIdResult = DeviceIdResult(
                 legacyArgs.deviceIdProvider.fingerprint(),
@@ -48,7 +48,7 @@ internal class FingerprinterImpl internal constructor(
 
     @WorkerThread
     fun getDeviceId(version: Fingerprinter.Version): Result<DeviceIdResult> {
-        return safe(timeoutMs = Safe.timeoutLong) {
+        return safe {
             DeviceIdResult(
                 deviceId = deviceIdSignalsProvider.getSignalMatching(version).getIdString(),
                 gsfId = deviceIdSignalsProvider.gsfIdSignal.getIdString(),
@@ -65,7 +65,7 @@ internal class FingerprinterImpl internal constructor(
     ): Result<FingerprintResult> {
         require(legacyArgs != null)
 
-        return safe(timeoutMs = Safe.timeoutLong) {
+        return safe {
             fingerprintResult?.let { return@safe it }
             val fingerprintSb = StringBuilder()
 
@@ -101,7 +101,7 @@ internal class FingerprinterImpl internal constructor(
         hasher: Hasher,
     ): Result<String> {
         return if (version < Fingerprinter.Version.fingerprintingFlattenedSignalsFirstVersion) {
-            safe(timeoutMs = Safe.timeoutLong) {
+            safe {
                 val joinedHashes = with(FingerprintingLegacySchemeSupportExtensions) {
                     listOf(
                         hasher.hash(fpSignalsProvider.getHardwareSignals(version, stabilityLevel)),
@@ -126,7 +126,7 @@ internal class FingerprinterImpl internal constructor(
         fingerprintingSignals: List<FingerprintingSignal<*>>,
         hasher: Hasher,
     ): Result<String> {
-        return safe(timeoutMs = Safe.timeoutLong) { hasher.hash(fingerprintingSignals) }
+        return safe { hasher.hash(fingerprintingSignals) }
     }
 
     internal fun getFingerprintingSignalsProvider(): FingerprintingSignalsProvider {

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/AndroidIdProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/AndroidIdProvider.kt
@@ -5,7 +5,7 @@ import android.annotation.SuppressLint
 import android.content.ContentResolver
 import android.provider.Settings
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -14,7 +14,7 @@ public class AndroidIdProvider(
 ) {
     @SuppressLint("HardwareIds")
     public fun getAndroidId(): String {
-        return safe {
+        return safeWithTimeout {
             Settings.Secure.getString(
                 contentResolver!!,
                 Settings.Secure.ANDROID_ID

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/GsfIdProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/GsfIdProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.device_id_providers
 import android.content.ContentResolver
 import android.net.Uri
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -13,7 +13,7 @@ public class GsfIdProvider(
 ) {
 
     public fun getGsfAndroidId(): String? {
-        return safe {
+        return safeWithTimeout {
             getGsfId()
         }.getOrDefault("")
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/MediaDrmIdProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/device_id_providers/MediaDrmIdProvider.kt
@@ -4,14 +4,14 @@ package com.fingerprintjs.android.fingerprint.device_id_providers
 import android.media.MediaDrm
 import android.os.Build
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 import java.security.MessageDigest
 import java.util.UUID
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
 public class MediaDrmIdProvider {
-    public fun getMediaDrmId(): String? = safe {
+    public fun getMediaDrmId(): String? = safeWithTimeout {
         mediaDrmId()
     }.getOrDefault(null)
 

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/BatteryInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/BatteryInfoProvider.kt
@@ -7,7 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -20,7 +20,7 @@ internal class BatteryInfoProviderImpl(
         private val applicationContext: Context
 ) : BatteryInfoProvider {
     override fun batteryHealth(): String {
-        return safe {
+        return safeWithTimeout {
             val intent = applicationContext
                 .registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))!!
 
@@ -36,7 +36,7 @@ internal class BatteryInfoProviderImpl(
 
     @SuppressLint("PrivateApi")
     override fun batteryTotalCapacity(): String {
-        return safe {
+        return safeWithTimeout {
             val mPowerProfile = Class.forName(POWER_PROFILE_CLASS_NAME)
                 .getConstructor(Context::class.java)
                 .newInstance(applicationContext)

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CameraInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CameraInfoProvider.kt
@@ -3,7 +3,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 
 import android.hardware.Camera
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 import java.util.LinkedList
 
 
@@ -22,7 +22,7 @@ public interface CameraInfoProvider {
 internal class CameraInfoProviderImpl(
 ) : CameraInfoProvider {
     override fun getCameraInfo(): List<CameraInfo> {
-        return safe {
+        return safeWithTimeout {
             extractInfo()
         }.getOrDefault(emptyList())
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CodecInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CodecInfoProvider.kt
@@ -3,7 +3,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 
 import android.media.MediaCodecList
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 public data class MediaCodecInfo(
@@ -20,7 +20,7 @@ internal class CodecInfoProviderImpl(
     private val codecList: MediaCodecList?,
 ) : CodecInfoProvider {
     override fun codecsList(): List<MediaCodecInfo> {
-        return safe {
+        return safeWithTimeout {
             extractCodecInfo()
         }.getOrDefault(emptyList())
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CpuInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/CpuInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.os.Build
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
 import com.fingerprintjs.android.fingerprint.tools.parsers.parseCpuInfo
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 import java.io.File
 import java.util.Scanner
 
@@ -33,26 +33,26 @@ public interface CpuInfoProvider {
 internal class CpuInfoProviderImpl :
     CpuInfoProvider {
     override fun cpuInfo(): Map<String, String> {
-        return safe {
+        return safeWithTimeout {
             getCpuInfo()
         }.getOrDefault(emptyMap())
     }
 
     override fun cpuInfoV2(): CpuInfo {
-        return safe {
+        return safeWithTimeout {
             getCpuInfoV2()
         }.getOrDefault(CpuInfo.EMPTY)
     }
 
     @Suppress("DEPRECATION")
     override fun abiType(): String {
-        return safe {
+        return safeWithTimeout {
             Build.SUPPORTED_ABIS[0]!!
         }.getOrDefault("")
     }
 
     override fun coresCount(): Int {
-        return safe {
+        return safeWithTimeout {
             Runtime.getRuntime()!!.availableProcessors()
         }.getOrDefault(0)
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DevicePersonalizationInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DevicePersonalizationInfoProvider.kt
@@ -5,7 +5,7 @@ import android.content.res.AssetManager
 import android.content.res.Configuration
 import android.media.RingtoneManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 import java.util.Locale
 import java.util.TimeZone
 
@@ -26,11 +26,11 @@ internal class DevicePersonalizationInfoProviderImpl(
 ) : DevicePersonalizationInfoProvider {
 
     override fun ringtoneSource(): String {
-        return safe{ ringtoneManager!!.getRingtoneUri(0)!!.toString()!! }.getOrDefault("")
+        return safeWithTimeout { ringtoneManager!!.getRingtoneUri(0)!!.toString()!! }.getOrDefault("")
     }
 
     override fun availableLocales(): Array<String> {
-        return safe {
+        return safeWithTimeout {
             assetManager!!.locales!!
                 .map { locale: String? -> locale.toString() }.toTypedArray()
         }.getOrDefault(emptyArray())
@@ -38,14 +38,14 @@ internal class DevicePersonalizationInfoProviderImpl(
 
     @Suppress("DEPRECATION")
     override fun regionCountry(): String {
-        return safe{ configuration!!.locale!!.country!! }.getOrDefault("")
+        return safeWithTimeout{ configuration!!.locale!!.country!! }.getOrDefault("")
     }
 
     override fun defaultLanguage(): String {
-        return safe { Locale.getDefault()!!.language!! } .getOrDefault("")
+        return safeWithTimeout { Locale.getDefault()!!.language!! } .getOrDefault("")
     }
 
     override fun timezone(): String {
-        return safe { TimeZone.getDefault()!!.displayName!! }.getOrDefault("")
+        return safeWithTimeout { TimeZone.getDefault()!!.displayName!! }.getOrDefault("")
     }
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DeviceSecurityInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/DeviceSecurityInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.app.KeyguardManager
 import android.app.admin.DevicePolicyManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 import java.security.Security
 
 
@@ -20,20 +20,20 @@ internal class DeviceSecurityInfoProviderImpl(
     private val keyguardManager: KeyguardManager?,
 ) : DeviceSecurityInfoProvider {
     override fun encryptionStatus(): String {
-        return safe {
+        return safeWithTimeout {
             stringDescriptionForEncryptionStatus(devicePolicyManager!!.storageEncryptionStatus)
         }.getOrDefault("")
     }
 
     override fun securityProvidersData(): List<Pair<String, String>> {
-        return safe {
+        return safeWithTimeout {
             Security.getProviders().map {
                 Pair(it!!.name!!, it.info ?: "")
             }
         }.getOrDefault(emptyList())
     }
 
-    override fun isPinSecurityEnabled() = safe {
+    override fun isPinSecurityEnabled() = safeWithTimeout {
         keyguardManager!!.isKeyguardSecure
     }.getOrDefault(false)
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/FingerprintSensorInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/FingerprintSensorInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.os.Build
 import androidx.core.hardware.fingerprint.FingerprintManagerCompat
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -16,7 +16,7 @@ internal class FingerprintSensorInfoProviderImpl(
     private val fingerprintManager: FingerprintManagerCompat?,
 ) : FingerprintSensorInfoProvider {
     override fun getStatus(): FingerprintSensorStatus {
-        return safe {
+        return safeWithTimeout {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                 FingerprintSensorStatus.NOT_SUPPORTED
             } else if (!fingerprintManager!!.isHardwareDetected) {

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/GpuInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/GpuInfoProvider.kt
@@ -3,7 +3,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 
 import android.app.ActivityManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -15,7 +15,7 @@ internal class GpuInfoProviderImpl(
     private val activityManager: ActivityManager?,
 ) : GpuInfoProvider {
     override fun glesVersion(): String {
-        return safe {
+        return safeWithTimeout {
             activityManager!!.deviceConfigurationInfo!!.glEsVersion!!
         }.getOrDefault("")
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/InputDevicesInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/InputDevicesInfoProvider.kt
@@ -3,7 +3,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 
 import android.hardware.input.InputManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -20,7 +20,7 @@ internal class InputDevicesDataSourceImpl(
     private val inputDeviceManager: InputManager?,
 ) : InputDeviceDataSource {
     override fun getInputDeviceData(): List<InputDeviceData> {
-        return safe {
+        return safeWithTimeout {
             inputDeviceManager!!.inputDeviceIds!!.map {
                 val inputDevice = inputDeviceManager.getInputDevice(it)!!
                 val vendorId = inputDevice.vendorId.toString()

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/MemInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/MemInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.app.ActivityManager
 import android.os.StatFs
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -20,7 +20,7 @@ internal class MemInfoProviderImpl(
     private val externalStorageStats: StatFs?,
 ) : MemInfoProvider {
     override fun totalRAM(): Long {
-        return safe {
+        return safeWithTimeout {
                 val memoryInfo = ActivityManager.MemoryInfo()
                 activityManager!!.getMemoryInfo(memoryInfo)
                 memoryInfo.totalMem
@@ -28,10 +28,10 @@ internal class MemInfoProviderImpl(
     }
 
     override fun totalInternalStorageSpace(): Long {
-        return safe { internalStorageStats!!.totalBytes }.getOrDefault(0)
+        return safeWithTimeout { internalStorageStats!!.totalBytes }.getOrDefault(0)
     }
 
     override fun totalExternalStorageSpace(): Long {
-        return safe { externalStorageStats!!.totalBytes }.getOrDefault(0)
+        return safeWithTimeout { externalStorageStats!!.totalBytes }.getOrDefault(0)
     }
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/OsBuildInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/OsBuildInfoProvider.kt
@@ -3,7 +3,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 
 import android.os.Build
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -19,26 +19,26 @@ public interface OsBuildInfoProvider {
 internal class OsBuildInfoProviderImpl :
     OsBuildInfoProvider {
     override fun modelName(): String {
-        return safe { Build.MODEL!! }.getOrDefault("")
+        return safeWithTimeout { Build.MODEL!! }.getOrDefault("")
     }
 
     override fun manufacturerName(): String {
-        return safe { Build.MANUFACTURER!! }.getOrDefault("")
+        return safeWithTimeout { Build.MANUFACTURER!! }.getOrDefault("")
     }
 
     override fun androidVersion(): String {
-        return safe { Build.VERSION.RELEASE!! }.getOrDefault("")
+        return safeWithTimeout { Build.VERSION.RELEASE!! }.getOrDefault("")
     }
 
     override fun sdkVersion(): String {
-        return safe { Build.VERSION.SDK_INT.toString() }.getOrDefault("")
+        return safeWithTimeout { Build.VERSION.SDK_INT.toString() }.getOrDefault("")
     }
 
     override fun kernelVersion(): String {
-        return safe { System.getProperty("os.version")!! }.getOrDefault("")
+        return safeWithTimeout { System.getProperty("os.version")!! }.getOrDefault("")
     }
 
     override fun fingerprint(): String {
-        return safe { Build.FINGERPRINT!! }.getOrDefault("")
+        return safeWithTimeout { Build.FINGERPRINT!! }.getOrDefault("")
     }
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/PackageManagerInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/PackageManagerInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -25,7 +25,7 @@ internal class PackageManagerDataSourceImpl(
     private val packageManager: PackageManager?,
 ) : PackageManagerDataSource {
     @SuppressLint("QueryPermissionsNeeded")
-    override fun getApplicationsList() = safe {
+    override fun getApplicationsList() = safeWithTimeout {
         packageManager!!
             .getInstalledApplications(PackageManager.GET_META_DATA)
             .map {
@@ -37,7 +37,7 @@ internal class PackageManagerDataSourceImpl(
 
 
     @SuppressLint("QueryPermissionsNeeded")
-    override fun getSystemApplicationsList() = safe {
+    override fun getSystemApplicationsList() = safeWithTimeout {
         packageManager!!
             .getInstalledApplications(PackageManager.GET_META_DATA)
             .filter {

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/SensorsInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/SensorsInfoProvider.kt
@@ -4,7 +4,7 @@ package com.fingerprintjs.android.fingerprint.info_providers
 import android.hardware.Sensor
 import android.hardware.SensorManager
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 public class SensorData(
@@ -21,7 +21,7 @@ internal class SensorDataSourceImpl(
     private val sensorManager: SensorManager?,
 ) : SensorDataSource {
     override fun sensors(): List<SensorData> {
-        return safe {
+        return safeWithTimeout {
                 sensorManager!!.getSensorList(Sensor.TYPE_ALL)!!.map {
                     SensorData(
                         it!!.name!!,

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/SettingsInfoProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/info_providers/SettingsInfoProvider.kt
@@ -5,7 +5,7 @@ import android.content.ContentResolver
 import android.os.Build
 import android.provider.Settings
 import com.fingerprintjs.android.fingerprint.tools.DeprecationMessages
-import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safeWithTimeout
 
 
 @Deprecated(message = DeprecationMessages.UNREACHABLE_SYMBOL_UNINTENDED_PUBLIC_API)
@@ -158,19 +158,19 @@ internal class SettingsDataSourceImpl(
     //endregion
 
     private fun extractGlobalSettingsParam(key: String): String {
-        return safe {
+        return safeWithTimeout {
             Settings.Global.getString(contentResolver!!, key)!!
         }.getOrDefault("")
     }
 
     private fun extractSecureSettingsParam(key: String): String {
-        return safe {
+        return safeWithTimeout {
             Settings.Secure.getString(contentResolver!!, key)!!
         }.getOrDefault("")
     }
 
     private fun extractSystemSettingsParam(key: String): String {
-        return safe {
+        return safeWithTimeout {
             Settings.System.getString(contentResolver!!, key)!!
         }.getOrDefault("")
     }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/threading/AnotherThread.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/threading/AnotherThread.kt
@@ -1,5 +1,7 @@
 package com.fingerprintjs.android.fingerprint.tools.threading
 
+import com.fingerprintjs.android.fingerprint.tools.threading.safe.safe
+
 /**
  * Returns immediately. The error relates to posting the job to another thread, not the error
  * that could have occurred on that thread.
@@ -7,6 +9,6 @@ package com.fingerprintjs.android.fingerprint.tools.threading
  */
 internal fun runOnAnotherThread(
     block: () -> Unit,
-): Result<Unit> = runCatching {
+): Result<Unit> = safe {
     sharedExecutor.submit { block() }
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/threading/safe/Safe.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/tools/threading/safe/Safe.kt
@@ -1,42 +1,54 @@
 package com.fingerprintjs.android.fingerprint.tools.threading.safe
 
+import androidx.annotation.VisibleForTesting
+import com.fingerprintjs.android.fingerprint.tools.logs.Logger
+import com.fingerprintjs.android.fingerprint.tools.logs.ePleaseReport
 import com.fingerprintjs.android.fingerprint.tools.threading.sharedExecutor
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.getOrSet
 
 internal object Safe {
     const val timeoutShort = 1_000L
-    const val timeoutLong = 3_000L
-    const val timeoutNop = 0L
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val runningInsideSafeWithTimeout = ThreadLocal<Boolean>()
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun logIllegalSafeWithTimeoutUsage() {
+        Logger.ePleaseReport(IllegalStateException())
+    }
 }
+
+internal inline fun <T> safe(block: () -> T) =
+    runCatching(block)
 
 /**
  * Runs the [block], catching all exceptions and handling unexpected execution locks (configured with [timeoutMs]).
  */
-internal fun <T> safe(
+internal fun <T> safeWithTimeout(
     timeoutMs: Long = Safe.timeoutShort,
-    block: () -> T,
-): Result<T> {
-    return when (timeoutMs) {
-        Safe.timeoutNop -> runCatching { block() }
-        else -> safeWithTimeout(timeoutMs, block)
-    }
-}
-
-private fun <T> safeWithTimeout(
-    timeoutMs: Long,
     block: () -> T,
 ): Result<T> {
     // we can't make a local variable volatile, hence using atomic reference here
     val executionThread = AtomicReference<Thread>(null)
 
+    if (Safe.runningInsideSafeWithTimeout.getOrSet { false }) {
+        Safe.logIllegalSafeWithTimeoutUsage()
+    }
+
     val future = runCatching {
         sharedExecutor.submit(
             Callable {
+                Safe.runningInsideSafeWithTimeout.set(true)
                 executionThread.set(Thread.currentThread())
-                block()
+                try {
+                    block()
+                } finally {
+                    Safe.runningInsideSafeWithTimeout.remove()
+                }
             }
         )!!
     }.getOrElse { return Result.failure(it) }


### PR DESCRIPTION
…predictable, as "structured concurrency" is not supported by safe call.