### PR TITLE
Fingerprint V6: update stable fingerprint

### DIFF
--- a/app/src/main/java/com/fingerprintjs/android/playground/utils/mappers/FingerprintingSignalsMappers.kt
+++ b/app/src/main/java/com/fingerprintjs/android/playground/utils/mappers/FingerprintingSignalsMappers.kt
@@ -14,6 +14,7 @@ val FingerprintingSignal<*>.humanName: String
         is ApplicationsListSignal -> "Applications List"
         is AvailableLocalesSignal -> "Available Locales"
         is BatteryFullCapacitySignal -> "Battery Full Capacity"
+        is BatteryFullCapacityV2Signal -> "Battery Full Capacity V2"
         is BatteryHealthSignal -> "Battery Health"
         is CameraListSignal -> "Camera List"
         is CodecListSignal -> "Codec List"
@@ -70,6 +71,7 @@ val FingerprintingSignal<*>.jsonifiableValue: Any
         is ApplicationsListSignal -> this.value.map { it.packageName }
         is AvailableLocalesSignal -> this.value
         is BatteryFullCapacitySignal -> this.value
+        is BatteryFullCapacityV2Signal -> this.value
         is BatteryHealthSignal -> this.value
         is CameraListSignal -> this.value.map {
             CameraListSignalItemVo(
@@ -154,6 +156,7 @@ val FingerprintingSignal<*>.humanValue: String
         is ApplicationsListSignal -> valueAsSimpleListString { appendLine(it) }
         is AvailableLocalesSignal -> valueAsSimpleListString { appendLine(it) }
         is BatteryFullCapacitySignal -> valueAsSimpleString()
+        is BatteryFullCapacityV2Signal -> valueAsSimpleString()
         is BatteryHealthSignal -> valueAsSimpleString()
         is CameraListSignal -> valueAsSeparatedListString {
             appendLine(it.cameraName)

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/Fingerprinter.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/Fingerprinter.kt
@@ -220,7 +220,8 @@ public class Fingerprinter internal constructor(
         V_2(intValue = 2),
         V_3(intValue = 3),
         V_4(intValue = 4),
-        V_5(intValue = 5);
+        V_5(intValue = 5),
+        V_6(intValue = 6);
 
         public companion object {
             @get:Discouraged(

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignals.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignals.kt
@@ -244,8 +244,30 @@ public class BatteryFullCapacitySignal(
     public companion object {
         public val info: Info = Info(
             addedInVersion = Fingerprinter.Version.V_2,
-            removedInVersion = null,
+            removedInVersion = Fingerprinter.Version.V_6,
             stabilityLevel = StabilityLevel.STABLE,
+        )
+    }
+}
+
+/**
+ * Same as [BatteryFullCapacitySignal], but [StabilityLevel] is downgraded to [StabilityLevel.OPTIMAL]
+ */
+public class BatteryFullCapacityV2Signal(
+    override val value: String,
+) : FingerprintingSignal<String>() {
+    override val info: Info
+        get() = Companion.info
+
+    override fun getHashableString(): String {
+        return value
+    }
+
+    public companion object {
+        public val info: Info = Info(
+            addedInVersion = Fingerprinter.Version.V_6,
+            removedInVersion = null,
+            stabilityLevel = StabilityLevel.OPTIMAL,
         )
     }
 }

--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignalsProvider.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/fingerprinting_signals/FingerprintingSignalsProvider.kt
@@ -78,6 +78,7 @@ public class FingerprintingSignalsProvider internal constructor(
             InputDevicesV2Signal.info to { inputDevicesV2Signal },
             BatteryHealthSignal.info to { batteryHealthSignal },
             BatteryFullCapacitySignal.info to { batteryFullCapacitySignal },
+            BatteryFullCapacityV2Signal.info to { batteryFullCapacityV2Signal },
             CameraListSignal.info to { cameraListSignal },
             GlesVersionSignal.info to { glesVersionSignal },
             AbiTypeSignal.info to { abiTypeSignal },
@@ -202,6 +203,11 @@ public class FingerprintingSignalsProvider internal constructor(
     @get:WorkerThread
     public val batteryFullCapacitySignal: BatteryFullCapacitySignal by lazy {
         BatteryFullCapacitySignal(batteryInfoProvider.batteryTotalCapacity())
+    }
+
+    @get:WorkerThread
+    public val batteryFullCapacityV2Signal: BatteryFullCapacityV2Signal by lazy {
+        BatteryFullCapacityV2Signal(batteryInfoProvider.batteryTotalCapacity())
     }
 
     @get:WorkerThread


### PR DESCRIPTION
Based on the report
https://github.com/fingerprintjs/fingerprintjs-android/issues/115 and also on our internal data, BatteryFullCapacitySignal could fluctuate occasionally on some devices. Although this signal provided some additional uniqueness to the stable fingerprint, the decision was made to move it to the "Optimal" stability tier to prioritise stability.

Implementation note: current code organization does not allow to make such changes easily, so I had to duplicate the original signal and assign it another stability level.